### PR TITLE
initial handleWindowProc result to nullopt

### DIFF
--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -169,8 +169,7 @@ void WindowManager::Maximize()
 
     if (windowPlacement.showCmd != SW_MAXIMIZE)
     {
-        windowPlacement.showCmd = SW_MAXIMIZE;
-        SetWindowPlacement(mainWindow, &windowPlacement);
+        PostMessage(mainWindow, WM_SYSCOMMAND, SC_MAXIMIZE, 0);
     }
 }
 
@@ -204,8 +203,7 @@ void WindowManager::Minimize()
 
     if (windowPlacement.showCmd != SW_SHOWMINIMIZED)
     {
-        windowPlacement.showCmd = SW_SHOWMINIMIZED;
-        SetWindowPlacement(mainWindow, &windowPlacement);
+        PostMessage(mainWindow, WM_SYSCOMMAND, SC_MINIMIZE, 0);
     }
 }
 
@@ -217,8 +215,7 @@ void WindowManager::Restore()
 
     if (windowPlacement.showCmd != SW_NORMAL)
     {
-        windowPlacement.showCmd = SW_NORMAL;
-        SetWindowPlacement(mainWindow, &windowPlacement);
+        PostMessage(mainWindow, WM_SYSCOMMAND, SC_RESTORE, 0);
     }
 }
 

--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -83,7 +83,7 @@ void WindowManagerPlugin::_EmitEvent(std::string eventName)
 
 std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    std::optional<LRESULT> result;
+    std::optional<LRESULT> result = std::nullopt;
 
     if (message == WM_NCCALCSIZE)
     {


### PR DESCRIPTION
fix #25 

给 handleWindowProc  的 result 加了一个 nullopt 初始值。

发现不给赋值为 nullopt 的话，那这个消息还是会被视为已消耗。这个会导致放大缩小之类操作没有系统动画。
