### PR TITLE
Fix WM_NCCALCSIZE,WM_NCHITTEST: All Border Resize

### DIFF
--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -108,12 +108,39 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd, UINT mes
             AdjustWindowRectEx(&borderThickness, GetWindowLongPtr(hWnd, GWL_STYLE) & ~WS_CAPTION, FALSE, NULL);
             NCCALCSIZE_PARAMS *sz = reinterpret_cast<NCCALCSIZE_PARAMS *>(lParam);
             // Add 1 pixel to the top border to make the window resizable from the top border
-            sz->rgrc[0].top -= 1;
-            sz->rgrc[0].right -= (borderThickness.right - 3);
-            sz->rgrc[0].bottom -= (borderThickness.bottom - 3);
+            sz->rgrc[0].top += 1;
+            sz->rgrc[0].right -= borderThickness.right;
+            sz->rgrc[0].bottom -= borderThickness.bottom;
+            sz->rgrc[0].left -= borderThickness.left;
 
             return (WVR_HREDRAW | WVR_VREDRAW);
         }
+    }
+	  else if (message == WM_NCHITTEST)
+    {
+        LONG width = 10;
+        POINT mouse = {LOWORD(lParam), HIWORD(lParam)};
+        RECT window;
+        GetWindowRect(hWnd, &window);
+        RECT rcFrame = {0};
+        // AdjustWindowRectEx(&rcFrame, WS_OVERLAPPEDWINDOW & ~WS_CAPTION, FALSE, NULL);
+        USHORT x = 1;
+        USHORT y = 1;
+        bool fOnResizeBorder = true;
+        if (mouse.y >= window.top && mouse.y < window.top + width)
+            x = 0;
+        else if (mouse.y < window.bottom && mouse.y >= window.bottom - width)
+            x = 2;
+        if (mouse.x >= window.left && mouse.x < window.left + width)
+            y = 0;
+        else if (mouse.x < window.right && mouse.x >= window.right - width)
+            y = 2;
+        LRESULT hitTests[3][3] = {
+            {HTTOPLEFT, fOnResizeBorder ? HTTOP : HTCAPTION, HTTOPRIGHT},
+            {HTLEFT, HTNOWHERE, HTRIGHT},
+            {HTBOTTOMLEFT, HTBOTTOM, HTBOTTOMRIGHT},
+        };
+        return hitTests[x][y];
     }
     else if (message == WM_GETMINMAXINFO)
     {


### PR DESCRIPTION
So I did some testing and found that these codes:
- Enables resizing from all border sides.
- Makes it so that the window doesn't resize that much (reduces only one pixel on the left, right, and bottom border) when changing titleBarStyle to "hidden".
- Removing the WM_NCHITTEST makes the edges (top left, bottom right, etc) resize region bigger than it should be.
- fOnResizeBorder should've been set to true (it was set to false) to enable resizing from top border.

Issues: 
- The top side originally goes inside the title bar so someone has to figure out how to do that in titleBarStyle = "hidden".
  The top border IS resizable in titleBarStyle = "hidden" but only for exactly 1 pixel and that is very annoying.
- SetResizable makes weird behavior (as usual) during titleBarStyle = "hidden"