### PR TITLE
Alternative method / workaround for setResizable

### DIFF
--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -38,6 +38,7 @@ class WindowManager
     bool is_frameless = false;
     std::string title_bar_style = "default";
     double opacity = 1;
+	bool is_resizable = true;
 
     // The minimum size set by the platform channel.
     POINT minimum_size = {0, 0};
@@ -438,19 +439,12 @@ void WindowManager::SetMaximumSize(const flutter::EncodableMap &args)
 
 bool WindowManager::IsResizable()
 {
-    HWND hWnd = GetMainWindow();
-    DWORD gwlStyle = GetWindowLong(hWnd, GWL_STYLE);
-    return (gwlStyle & WS_THICKFRAME) != 0;
+	return this->is_resizable;
 }
 
 void WindowManager::SetResizable(const flutter::EncodableMap &args)
 {
-    HWND hWnd = GetMainWindow();
-    bool isResizable = std::get<bool>(args.at(flutter::EncodableValue("isResizable")));
-    DWORD gwlStyle = GetWindowLong(hWnd, GWL_STYLE);
-    gwlStyle = isResizable ? gwlStyle | WS_THICKFRAME : gwlStyle & ~WS_THICKFRAME;
-    SetWindowLong(hWnd, GWL_STYLE, gwlStyle);
-	SetWindowPos(hWnd, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_DRAWFRAME);
+    this->is_resizable = std::get<bool>(args.at(flutter::EncodableValue("isResizable")));
 }
 
 bool WindowManager::IsMinimizable()

--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -100,15 +100,14 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd, UINT mes
             GetWindowPlacement(hWnd, &wPos);
             RECT borderThickness;
             SetRectEmpty(&borderThickness);
-            AdjustWindowRectEx(&borderThickness, GetWindowLongPtr(hWnd, GWL_STYLE) & ~WS_CAPTION & WS_BORDER, FALSE, NULL);
+            AdjustWindowRectEx(&borderThickness, GetWindowLongPtr(hWnd, GWL_STYLE) & ~WS_CAPTION, FALSE, NULL);
             NCCALCSIZE_PARAMS *sz = reinterpret_cast<NCCALCSIZE_PARAMS *>(lParam);
 			
-			bool isResizable = window_manager->IsResizable();
             // Add 1 pixel to the top border to make the window resizable from the top border
-            sz->rgrc[0].top += isResizable ? 1 : 0;
-            sz->rgrc[0].right -= isResizable ? 7 : 0;
-            sz->rgrc[0].bottom -= isResizable ? 7 : 0;
-            sz->rgrc[0].left += isResizable ? 7 : 0;
+            sz->rgrc[0].top += 1;
+            sz->rgrc[0].right -= borderThickness.right;
+            sz->rgrc[0].bottom -= borderThickness.bottom;
+            sz->rgrc[0].left -= borderThickness.left;
 
             return (WVR_HREDRAW | WVR_VREDRAW);
         }
@@ -120,6 +119,10 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd, UINT mes
     }
     else  if (message == WM_NCHITTEST)
     {
+		bool isResizable = window_manager->is_resizable;
+		if (!isResizable) {
+			return HTNOWHERE;
+		}
         LONG width = 10;
         POINT mouse = {LOWORD(lParam), HIWORD(lParam)};
         RECT window;


### PR DESCRIPTION
Basically
- Adds a new variable is_resizable to check if window is/n't resizable.
- Changes IsResizable() to return is_resizable and SetResizable to change is_resizable.
- If not is_resizable, WM_NCHITTEST returns HTNOWHERE which makes hovering and clicking the edges of the window does nothing.