### PR TITLE
[Windows] Fix animation titlebar=hidden, add startResize()

### DIFF
--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -545,6 +545,26 @@ class WindowManager {
   Future<void> startDragging() async {
     await _channel.invokeMethod('startDragging');
   }
+  
+  Future<void> startResize(DragPosition position) {
+    return _channel.invokeMethod<bool>(
+      'startResize',
+      {
+        "top": position == DragPosition.top ||
+            position == DragPosition.topLeft ||
+            position == DragPosition.topRight,
+        "bottom": position == DragPosition.bottom ||
+            position == DragPosition.bottomLeft ||
+            position == DragPosition.bottomRight,
+        "right": position == DragPosition.right ||
+            position == DragPosition.topRight ||
+            position == DragPosition.bottomRight,
+        "left": position == DragPosition.left ||
+            position == DragPosition.topLeft ||
+            position == DragPosition.bottomLeft,
+      },
+    );
+  }
 
   Future<Map<String, dynamic>> _getPrimaryDisplay() async {
     final Map<String, dynamic> arguments = {
@@ -578,3 +598,14 @@ class WindowManager {
 }
 
 final windowManager = WindowManager.instance;
+
+enum DragPosition {
+  top,
+  left,
+  right,
+  bottom,
+  topLeft,
+  bottomLeft,
+  topRight,
+  bottomRight
+}

--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -559,7 +559,9 @@ int WindowManager::GetTitleBarHeight() {
   TITLEBARINFOEX* ptinfo = (TITLEBARINFOEX*)malloc(sizeof(TITLEBARINFOEX));
   ptinfo->cbSize = sizeof(TITLEBARINFOEX);
   SendMessage(hWnd, WM_GETTITLEBARINFOEX, 0, (LPARAM)ptinfo);
-  int height = ptinfo->rcTitleBar.bottom - ptinfo->rcTitleBar.top;
+  int height = ptinfo->rcTitleBar.bottom == 0
+                   ? 0
+                   : ptinfo->rcTitleBar.bottom - ptinfo->rcTitleBar.top;
   free(ptinfo);
 
   return height;


### PR DESCRIPTION
- Enables animation/transition during minimize, maximize, etc (aero) on titleBarStyle = "hidden"

- Added a bug that removes top resize border except for the top left and top right
This is a temporary solution until we can somehow implement
https://github.com/rossy/borderless-window
and/or
https://github.com/melak47/BorderlessWindow

- Added startResize() method on Windows in case someone (me) wants to make a workaround widget for the top resize border