### PR TITLE
[Windows] Remove border, setAsFrameless: Enable reset to TitleBarStyle, remove resizing jitter

### DIFF
--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -129,7 +129,7 @@ void WindowManager::SetAsFrameless() {
   MARGINS margins = {0, 0, 0, 0};
 
   GetWindowRect(hWnd, &rect);
-  SetWindowLong(hWnd, GWL_STYLE, WS_POPUP | WS_CAPTION | WS_VISIBLE);
+  SetWindowLong(hWnd, GWL_STYLE, WS_POPUP            | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX);
   DwmExtendFrameIntoClientArea(hWnd, &margins);
   SetWindowPos(hWnd, nullptr, rect.left, rect.top, rect.right - rect.left,
                rect.bottom - rect.top,
@@ -564,11 +564,14 @@ void WindowManager::SetTitleBarStyle(const flutter::EncodableMap& args) {
 
   HWND hWnd = GetMainWindow();
   DWORD gwlStyle = GetWindowLong(hWnd, GWL_STYLE);
+  // Enables the ability to go from setAsFrameless() to TitleBarStyle.normal/hidden
+  is_frameless_ = false;
   if (title_bar_style_ == "hidden") {
-    gwlStyle = gwlStyle | WS_POPUP;
+    gwlStyle = WS_POPUP            | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX;
     SetWindowLong(hWnd, GWL_STYLE, gwlStyle);
-  } else {
-    gwlStyle = gwlStyle & ~WS_POPUP;
+  } 
+  else {
+    gwlStyle = WS_OVERLAPPEDWINDOW | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
     SetWindowLong(hWnd, GWL_STYLE, gwlStyle);
   }
 

--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -129,7 +129,7 @@ void WindowManager::SetAsFrameless() {
   MARGINS margins = {0, 0, 0, 0};
 
   GetWindowRect(hWnd, &rect);
-  SetWindowLong(hWnd, GWL_STYLE, WS_POPUP            | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX);
+  SetWindowLong(hWnd, GWL_STYLE, WS_POPUP            | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX | WS_VISIBLE);
   DwmExtendFrameIntoClientArea(hWnd, &margins);
   SetWindowPos(hWnd, nullptr, rect.left, rect.top, rect.right - rect.left,
                rect.bottom - rect.top,
@@ -567,7 +567,7 @@ void WindowManager::SetTitleBarStyle(const flutter::EncodableMap& args) {
   // Enables the ability to go from setAsFrameless() to TitleBarStyle.normal/hidden
   is_frameless_ = false;
   if (title_bar_style_ == "hidden") {
-    gwlStyle = WS_POPUP            | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX;
+    gwlStyle = WS_POPUP            | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX | WS_VISIBLE;
     SetWindowLong(hWnd, GWL_STYLE, gwlStyle);
 	BOOL composition_enabled = FALSE;
 	bool success = DwmIsCompositionEnabled(&composition_enabled) == S_OK;
@@ -578,7 +578,7 @@ void WindowManager::SetTitleBarStyle(const flutter::EncodableMap& args) {
 	}
   } 
   else {
-    gwlStyle = WS_OVERLAPPEDWINDOW | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+    gwlStyle = WS_OVERLAPPEDWINDOW | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_VISIBLE;
     SetWindowLong(hWnd, GWL_STYLE, gwlStyle);
   }
 

--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -569,6 +569,13 @@ void WindowManager::SetTitleBarStyle(const flutter::EncodableMap& args) {
   if (title_bar_style_ == "hidden") {
     gwlStyle = WS_POPUP            | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX;
     SetWindowLong(hWnd, GWL_STYLE, gwlStyle);
+	BOOL composition_enabled = FALSE;
+	bool success = DwmIsCompositionEnabled(&composition_enabled) == S_OK;
+	if (composition_enabled && success) {
+		static const MARGINS shadow_state[2]{ { 0,0,0,0 },{ 1,1,1,1 } };
+		DwmExtendFrameIntoClientArea(hWnd, &shadow_state[0]);
+		ShowWindow(hWnd, SW_SHOW);
+	}
   } 
   else {
     gwlStyle = WS_OVERLAPPEDWINDOW | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;

--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -111,7 +111,9 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
   if (message == WM_NCCALCSIZE) {
     if (wParam && window_manager->is_frameless_) {
       SetWindowLong(hWnd, 0, 0);
-      return 1;
+      NCCALCSIZE_PARAMS* sz = reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam);
+      sz->rgrc[0].bottom += 1;
+      return (WVR_HREDRAW | WVR_VREDRAW);
     }
 
     if (wParam && window_manager->title_bar_style_ == "hidden") {


### PR DESCRIPTION
- Enables resetting window style to TitleBarStyle.normal/hidden from setAsFrameless(). Fixes #68 
- Removes crazy jittering when resizing window
- Starting point for window border removal (not yet working)