### PR TITLE
[Windows] Remove unnecessary code, implement hasShadow and setHasShadow in frameless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,14 +653,14 @@ Makes the window not show in the taskbar / dock.
 Sets progress value in progress bar. Valid range is [0, 1.0].
 
 
-##### hasShadow  `macos`
+##### hasShadow  `macos`  `windows`
 
-Returns `bool` - Whether the window has a shadow.
+Returns `bool` - Whether the window has a shadow. On Windows, always returns true unless window is frameless.
 
 
-##### setHasShadow  `macos`
+##### setHasShadow  `macos`  `windows`
 
-Sets whether the window should have a shadow.
+Sets whether the window should have a shadow. On Windows, doesn't do anything unless window is frameless.
 
 
 ##### getOpacity  `macos`  `windows`

--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -531,16 +531,16 @@ class WindowManager {
     await _channel.invokeMethod('setProgressBar', arguments);
   }
 
-  /// Returns `bool` - Whether the window has a shadow.
+  /// Returns `bool` - Whether the window has a shadow. On Windows, always returns true unless window is frameless.
   ///
-  /// @platforms macos
+  /// @platforms macos,windows
   Future<bool> hasShadow() async {
     return await _channel.invokeMethod('hasShadow');
   }
 
-  /// Sets whether the window should have a shadow.
+  /// Sets whether the window should have a shadow. On Windows, doesn't do anything unless window is frameless.
   ///
-  /// @platforms macos
+  /// @platforms macos,windows
   Future<void> setHasShadow(bool hasShadow) async {
     final Map<String, dynamic> arguments = {
       'hasShadow': hasShadow,

--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -35,6 +35,7 @@ class WindowManager {
 
   int last_state = STATE_NORMAL;
 
+  bool has_shadow_ = false;
   bool is_frameless_ = false;
   bool is_prevent_close_ = false;
   double aspect_ratio_ = 0;
@@ -127,6 +128,7 @@ void WindowManager::SetAsFrameless() {
   HWND hWnd = GetMainWindow();
 
   RECT rect;
+
   GetWindowRect(hWnd, &rect);
   SetWindowPos(hWnd, nullptr, rect.left, rect.top, rect.right - rect.left,
                rect.bottom - rect.top,
@@ -554,12 +556,13 @@ void WindowManager::SetTitleBarStyle(const flutter::EncodableMap& args) {
       std::get<std::string>(args.at(flutter::EncodableValue("titleBarStyle")));
   // Enables the ability to go from setAsFrameless() to
   // TitleBarStyle.normal/hidden
-	
   is_frameless_ = false;
 
+  MARGINS margins = {0, 0, 0, 0};
   HWND hWnd = GetMainWindow();
   RECT rect;
   GetWindowRect(hWnd, &rect);
+  DwmExtendFrameIntoClientArea(hWnd, &margins);
   SetWindowPos(hWnd, nullptr, rect.left, rect.top, 0, 0,
                SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOMOVE | SWP_NOSIZE |
                    SWP_FRAMECHANGED);
@@ -616,6 +619,24 @@ void WindowManager::SetProgressBar(const flutter::EncodableMap& args) {
     taskbar_->SetProgressState(hWnd, TBPF_INDETERMINATE);
     taskbar_->SetProgressValue(hWnd, static_cast<int32_t>(progress * 100),
                                static_cast<int32_t>(100));
+  }
+}
+
+bool WindowManager::HasShadow() {
+  if (is_frameless_)
+    return has_shadow_;
+  return true;
+}
+
+void WindowManager::SetHasShadow(const flutter::EncodableMap& args) {
+  if (is_frameless_) {
+    has_shadow_ = std::get<bool>(args.at(flutter::EncodableValue("hasShadow")));
+
+    HWND hWnd = GetMainWindow();
+
+    MARGINS margins[2]{{0, 0, 0, 0}, {0, 0, 1, 0}};
+
+    DwmExtendFrameIntoClientArea(hWnd, &margins[has_shadow_]);
   }
 }
 

--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -128,6 +128,8 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
         sz->rgrc[0].right -= 8;
         sz->rgrc[0].bottom -= 9;
       }
+      // This cuts the app at the bottom by one pixel but that's necessary to
+      // prevent jitter when resizing the app
       sz->rgrc[0].bottom += 1;
       return 0;
     }
@@ -458,6 +460,14 @@ void WindowManagerPlugin::HandleMethodCall(
     const flutter::EncodableMap& args =
         std::get<flutter::EncodableMap>(*method_call.arguments());
     window_manager->SetProgressBar(args);
+    result->Success(flutter::EncodableValue(true));
+  } else if (method_name.compare("hasShadow") == 0) {
+    bool value = window_manager->HasShadow();
+    result->Success(flutter::EncodableValue(value));
+  } else if (method_name.compare("setHasShadow") == 0) {
+    const flutter::EncodableMap& args =
+        std::get<flutter::EncodableMap>(*method_call.arguments());
+    window_manager->SetHasShadow(args);
     result->Success(flutter::EncodableValue(true));
   } else if (method_name.compare("getOpacity") == 0) {
     double value = window_manager->GetOpacity();


### PR DESCRIPTION
- Removed ~50 lines of code that doesn't do anything and when removed doesn't break anything
- Implemented `hasShadow` and `setHasShadow` in frameless mode (`setAsFrameless()`)

Note:
`hasShadow()` and `setHasShadow()` will only work in frameless mode. Otherwise (`TitleBarStyle.normal/hidden`), `hasShadow()` will always return true.
This is because in Windows, according to my experience, a window's shadow will only be removed/hidden if the client area is fully covering the window frame (
```cpp
MARGINS margins = {0, 0, 0, 0};
DwmExtendFrameIntoClientArea(hWnd, &margins[has_shadow_]);
```
).

However, if the app doesn't cover the window frame, even if only on one side (
```cpp
MARGINS margins = {0, 0, 1, 0};
DwmExtendFrameIntoClientArea(hWnd, &margins[has_shadow_]);
```
), the shadow will reappear.

Also note that to enable resizing in frameless mode, You must wrap the app with `VirtualWindowFrame` with all `ResizeEdge`s enabled. However, this will only enable mouse resize border inside the app, unlike `TitleBarStyle.hidden`, which still has invisible frame with resizable border on the left, bottom, and right side of the app.

In the future, I would like to replicate Microsoft Office apps, which has 4 separate windows on each border with class name `MSO_BORDEREFFECT_WINDOW_CLASS` and `WS_EX_TOOLWINDOW` style. I think it also draws/paints a fake shadow on its own and is used to resize the app outside the app. I took this conclusion because when I hid that window using WinSpy+, the shadow disappears and I can no longer resize the app outside the window.
If we succeed, we don't have to worry about not being able to interact with any widget on the border of the app while still enabling resize border and window shadow.