### PR TITLE
Allow setSize to set position & animate setBounds/center

### DIFF
--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -268,9 +268,9 @@ class WindowManager {
   }
 
   /// Resizes and moves the window to the supplied bounds.
-  Future<void> setBounds(Rect bounds, {animate = false}) async {
-    await setPosition(bounds.topLeft);
-    await setSize(bounds.size);
+  Future<void> setBounds(Rect bounds, {bool animate = false}) async {
+    await setPosition(bounds.topLeft, animate: animate);
+    await setSize(bounds.size, animate: animate);
   }
 
   /// Returns `Offset` - Contains the window's current position.
@@ -351,7 +351,7 @@ class WindowManager {
   }
 
   /// Moves window to the center of the screen.
-  Future<void> center() async {
+  Future<void> center([bool animate = false]) async {
     Size windowSize = await getSize();
     Map<String, dynamic> primaryDisplay = await _getPrimaryDisplay();
 
@@ -374,11 +374,11 @@ class WindowManager {
       visibleStartY + ((visibleHeight / 2) - (windowSize.height / 2)),
     );
 
-    await this.setPosition(position);
+    await this.setPosition(position, animate: animate);
   }
 
   /// Moves window to position.
-  Future<void> setPosition(Offset position, {animate = false}) async {
+  Future<void> setPosition(Offset position, {bool animate = false}) async {
     final Map<String, dynamic> arguments = {
       'devicePixelRatio': window.devicePixelRatio,
       'x': position.dx,
@@ -399,11 +399,17 @@ class WindowManager {
   }
 
   /// Resizes the window to `width` and `height`.
-  Future<void> setSize(Size size, {animate = false}) async {
+  Future<void> setSize(
+    Size size, {
+    bool animate = false,
+    Offset? position,
+  }) async {
     final Map<String, dynamic> arguments = {
       'devicePixelRatio': window.devicePixelRatio,
       'width': size.width,
       'height': size.height,
+      'x': position?.dx,
+      'y': position?.dy,
       'animate': animate,
     }..removeWhere((key, value) => value == null);
     await _channel.invokeMethod('setSize', arguments);

--- a/macos/Classes/WindowManager.swift
+++ b/macos/Classes/WindowManager.swift
@@ -247,6 +247,7 @@ public class WindowManager: NSObject, NSWindowDelegate {
     
     public func setSize(_ args: [String: Any]) {
         let animate = args["animate"] as? Bool ?? false
+        let center = args["center"] as? Bool ?? false
         
         var frameRect = mainWindow.frame
         if (args["width"] != nil && args["height"] != nil) {
@@ -257,6 +258,10 @@ public class WindowManager: NSObject, NSWindowDelegate {
             frameRect.size.width = width
             frameRect.size.height = height
             
+        }
+        if (args["x"] != nil && args["y"] != nil) {
+            frameRect.topLeft.x = CGFloat(args["x"] as! Float)
+            frameRect.topLeft.y = CGFloat(args["y"] as! Float)
         }
         
         if (animate) {

--- a/macos/Classes/WindowManager.swift
+++ b/macos/Classes/WindowManager.swift
@@ -247,7 +247,6 @@ public class WindowManager: NSObject, NSWindowDelegate {
     
     public func setSize(_ args: [String: Any]) {
         let animate = args["animate"] as? Bool ?? false
-        let center = args["center"] as? Bool ?? false
         
         var frameRect = mainWindow.frame
         if (args["width"] != nil && args["height"] != nil) {


### PR DESCRIPTION
This pull request makes the following fixes:
- `center`/`setBounds` can now animate
- `setSize` allows the x/y coordinates to be used.

Fixes #142 

Current behavior with `setBounds`

https://user-images.githubusercontent.com/6907797/167905546-f3626168-7dba-4395-bd73-ee88253eb667.mp4

Desired behavior after changes:

https://user-images.githubusercontent.com/6907797/167905237-3985e1d1-dbf4-4951-9568-17ca89938752.mp4


