### PR TITLE
Remove decoration for maximized window

### DIFF
--- a/lib/src/widgets/virtual_window_frame.dart
+++ b/lib/src/widgets/virtual_window_frame.dart
@@ -49,20 +49,25 @@ class _VirtualWindowFrameState extends State<VirtualWindowFrame>
       margin: (_isMaximized || _isFullScreen)
           ? EdgeInsets.zero
           : EdgeInsets.all(kVirtualWindowFrameMargin),
-      decoration: BoxDecoration(
-        color: Colors.transparent,
-        border: Border.all(color: Theme.of(context).dividerColor, width: 1),
-        borderRadius: BorderRadius.circular(6),
-        boxShadow: <BoxShadow>[
-          BoxShadow(
-            color: Colors.black.withOpacity(0.1),
-            offset: Offset(0.0, _isFocused ? 4 : 2),
-            blurRadius: 6,
-          ),
-        ],
-      ),
+      decoration: (_isMaximized || _isFullScreen)
+          ? BoxDecoration()
+          : BoxDecoration(
+              color: Colors.transparent,
+              border:
+                  Border.all(color: Theme.of(context).dividerColor, width: 1),
+              borderRadius: BorderRadius.circular(6),
+              boxShadow: <BoxShadow>[
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.1),
+                  offset: Offset(0.0, _isFocused ? 4 : 2),
+                  blurRadius: 6,
+                ),
+              ],
+            ),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(6),
+        borderRadius: (_isMaximized || _isFullScreen)
+            ? BorderRadius.zero
+            : BorderRadius.circular(6),
         child: widget.child,
       ),
     );

--- a/lib/src/widgets/virtual_window_frame.dart
+++ b/lib/src/widgets/virtual_window_frame.dart
@@ -49,25 +49,28 @@ class _VirtualWindowFrameState extends State<VirtualWindowFrame>
       margin: (_isMaximized || _isFullScreen)
           ? EdgeInsets.zero
           : EdgeInsets.all(kVirtualWindowFrameMargin),
-      decoration: (_isMaximized || _isFullScreen)
-          ? BoxDecoration()
-          : BoxDecoration(
-              color: Colors.transparent,
-              border:
-                  Border.all(color: Theme.of(context).dividerColor, width: 1),
-              borderRadius: BorderRadius.circular(6),
-              boxShadow: <BoxShadow>[
-                BoxShadow(
-                  color: Colors.black.withOpacity(0.1),
-                  offset: Offset(0.0, _isFocused ? 4 : 2),
-                  blurRadius: 6,
-                ),
-              ],
+      decoration: BoxDecoration(
+        color: Colors.transparent,
+        border: Border.all(
+          color: Theme.of(context).dividerColor,
+          width: (_isMaximized || _isFullScreen) ? 0 : 1,
+        ),
+        borderRadius: BorderRadius.circular(
+          (_isMaximized || _isFullScreen) ? 0 : 6,
+        ),
+        boxShadow: <BoxShadow>[
+          if (!_isMaximized && !_isFullScreen)
+            BoxShadow(
+              color: Colors.black.withOpacity(0.1),
+              offset: Offset(0.0, _isFocused ? 4 : 2),
+              blurRadius: 6,
             ),
+        ],
+      ),
       child: ClipRRect(
-        borderRadius: (_isMaximized || _isFullScreen)
-            ? BorderRadius.zero
-            : BorderRadius.circular(6),
+        borderRadius: BorderRadius.circular(
+          (_isMaximized || _isFullScreen) ? 0 : 6,
+        ),
         child: widget.child,
       ),
     );


### PR DESCRIPTION
Currently the virtual frame has border radius even in maximize or full screen state, this PR removes that.

Normal Window:
<img src="https://user-images.githubusercontent.com/41370460/182022226-603a2de6-219f-43ad-90d9-2ca0002aa384.png" width="300">
Maximized Window:
<img src="https://user-images.githubusercontent.com/41370460/182022231-35b6aa59-3c64-4055-823d-a1f75869d1e5.png" width="600">

