### PR TITLE
[macos]fix crash lead by fast clicks

### DIFF
--- a/macos/Classes/WindowManager.swift
+++ b/macos/Classes/WindowManager.swift
@@ -443,7 +443,9 @@ public class WindowManager: NSObject, NSWindowDelegate {
     public func startDragging() {
         DispatchQueue.main.async {
             let window: NSWindow  = self.mainWindow
-            window.performDrag(with: window.currentEvent!)
+            if(window.currentEvent != nil) {
+                window.performDrag(with: window.currentEvent!)
+            }
         }
     }
     


### PR DESCRIPTION
window.currentEvent may be nil when call this method rapidly that will cause crash