### PR TITLE
Linux: fix bottom edge resizing

### DIFF
--- a/linux/window_manager_plugin.cc
+++ b/linux/window_manager_plugin.cc
@@ -547,11 +547,11 @@ static FlMethodResponse* start_resizing(WindowManagerPlugin* self,
     gdk_window_edge = GDK_WINDOW_EDGE_WEST;
   } else if (strcmp(resize_edge, "right") == 0) {
     gdk_window_edge = GDK_WINDOW_EDGE_EAST;
-  } else if (strcmp(resize_edge, "bottomLeft")) {
+  } else if (strcmp(resize_edge, "bottomLeft") == 0) {
     gdk_window_edge = GDK_WINDOW_EDGE_SOUTH_WEST;
-  } else if (strcmp(resize_edge, "bottom")) {
+  } else if (strcmp(resize_edge, "bottom") == 0) {
     gdk_window_edge = GDK_WINDOW_EDGE_SOUTH;
-  } else if (strcmp(resize_edge, "bottomRight")) {
+  } else if (strcmp(resize_edge, "bottomRight") == 0) {
     gdk_window_edge = GDK_WINDOW_EDGE_SOUTH_EAST;
   }
 


### PR DESCRIPTION
Resizing by bottom left, bottom or bottom right were not working correctly on Linux.

With this change they behave like the correct edge.