### PR TITLE
[Windows] make setMinimum/MaximumSize() dpi change awareable

### DIFF
--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -51,6 +51,7 @@ class WindowManager {
   double aspect_ratio_ = 0;
   POINT minimum_size_ = {0, 0};
   POINT maximum_size_ = {-1, -1};
+  double pixel_ratio_ = 1;
   bool is_resizable_ = true;
   bool is_skip_taskbar_ = true;
   std::string title_bar_style_ = "normal";

--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -532,9 +532,10 @@ void WindowManager::SetMinimumSize(const flutter::EncodableMap& args) {
   double height = std::get<double>(args.at(flutter::EncodableValue("height")));
 
   if (width >= 0 && height >= 0) {
+    pixel_ratio_ = devicePixelRatio;
     POINT point = {};
-    point.x = static_cast<LONG>(width * devicePixelRatio);
-    point.y = static_cast<LONG>(height * devicePixelRatio);
+    point.x = static_cast<LONG>(width);
+    point.y = static_cast<LONG>(height);
     minimum_size_ = point;
   }
 }
@@ -546,9 +547,10 @@ void WindowManager::SetMaximumSize(const flutter::EncodableMap& args) {
   double height = std::get<double>(args.at(flutter::EncodableValue("height")));
 
   if (width >= 0 && height >= 0) {
+    pixel_ratio_ = devicePixelRatio;
     POINT point = {};
-    point.x = static_cast<LONG>(width * devicePixelRatio);
-    point.y = static_cast<LONG>(height * devicePixelRatio);
+    point.x = static_cast<LONG>(width);
+    point.y = static_cast<LONG>(height);
     maximum_size_ = point;
   }
 }

--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -108,6 +108,10 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
                                                              LPARAM lParam) {
   std::optional<LRESULT> result = std::nullopt;
 
+  if (message == WM_DPICHANGED) {
+    window_manager->pixel_ratio_ = LOWORD(wParam) / 96.0;
+  }
+
   if (message == WM_NCCALCSIZE) {
     // This must always be first or else the one of other two ifs will execute
     //  when window is in full screen and we don't want that
@@ -163,13 +167,21 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
     MINMAXINFO* info = reinterpret_cast<MINMAXINFO*>(lParam);
     // For the special "unconstrained" values, leave the defaults.
     if (window_manager->minimum_size_.x != 0)
-      info->ptMinTrackSize.x = window_manager->minimum_size_.x;
+      info->ptMinTrackSize.x =
+          static_cast<LONG> (window_manager->minimum_size_.x *
+          window_manager->pixel_ratio_);
     if (window_manager->minimum_size_.y != 0)
-      info->ptMinTrackSize.y = window_manager->minimum_size_.y;
+      info->ptMinTrackSize.y =
+          static_cast<LONG> (window_manager->minimum_size_.y *
+          window_manager->pixel_ratio_);
     if (window_manager->maximum_size_.x != -1)
-      info->ptMaxTrackSize.x = window_manager->maximum_size_.x;
+      info->ptMaxTrackSize.x =
+          static_cast<LONG> (window_manager->maximum_size_.x *
+          window_manager->pixel_ratio_);
     if (window_manager->maximum_size_.y != -1)
-      info->ptMaxTrackSize.y = window_manager->maximum_size_.y;
+      info->ptMaxTrackSize.y =
+          static_cast<LONG> (window_manager->maximum_size_.y *
+          window_manager->pixel_ratio_);
     result = 0;
   } else if (message == WM_NCACTIVATE) {
     if (wParam == TRUE) {

--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -109,7 +109,7 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
   std::optional<LRESULT> result = std::nullopt;
 
   if (message == WM_DPICHANGED) {
-    window_manager->pixel_ratio_ = LOWORD(wParam) / 96.0;
+    window_manager->pixel_ratio_ = (float) LOWORD(wParam) / USER_DEFAULT_SCREEN_DPI;
   }
 
   if (message == WM_NCCALCSIZE) {


### PR DESCRIPTION
Current implemention of setMinimum/MaximumSize() on Windows platform only get device pixel ratio once at the functions called.  When user has multiple monitors with different dpi, this implementation will cause window size issue (too big / small) after drag the window to another monitor.

This PR implements dpi change awareness feature for setMinimum/MaximumSize(). 