### PR TITLE
Fix Unable to bridge NSNumber to Float

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 .dart_tool/
-
+.idea/
 .packages
 .pub/
 

--- a/macos/Classes/WindowManager.swift
+++ b/macos/Classes/WindowManager.swift
@@ -235,8 +235,8 @@ public class WindowManager: NSObject, NSWindowDelegate {
         }
         
         if (args["x"] != nil && args["y"] != nil) {
-            frameRect.topLeft.x = CGFloat(args["x"] as! Float)
-            frameRect.topLeft.y = CGFloat(args["y"] as! Float)
+            frameRect.topLeft.x = CGFloat(truncating: args["x"] as! NSNumber)
+            frameRect.topLeft.y = CGFloat(truncating: args["y"] as! NSNumber)
         }
         
         if (animate) {


### PR DESCRIPTION
Foundation/NSNumber.swift:467: Fatal error: Unable to bridge NSNumber to Float