### PR TITLE
fix: offset lost after invoking gtk hide on linux

### DIFF
--- a/linux/window_manager_plugin.cc
+++ b/linux/window_manager_plugin.cc
@@ -126,7 +126,14 @@ static FlMethodResponse* show(WindowManagerPlugin* self) {
 }
 
 static FlMethodResponse* hide(WindowManagerPlugin* self) {
+  gint x, y, width, height;
+  // store the bound of window before hide
+  gtk_window_get_position(get_window(self), &x, &y);
+  gtk_window_get_size(get_window(self), &width, &height);
   gtk_widget_hide(GTK_WIDGET(get_window(self)));
+  // restore the bound of window after hide
+  gtk_window_move(get_window(self), x, y);
+  gtk_window_resize(get_window(self), width, height);
   g_autoptr(FlValue) result = fl_value_new_bool(true);
   return FL_METHOD_RESPONSE(fl_method_success_response_new(result));
 }


### PR DESCRIPTION
I've found there's an issue when using `gtk_widget_hide` method, causing offset lost after hide the window (always center).

Reproduce repo(pure empty flutter project + window_manager): https://github.com/Kingtous/hide_and_show_issue_reproduce_demo

![flutter](https://user-images.githubusercontent.com/39793325/200823109-cb9c495b-c4cd-49a4-be9a-67d00d776045.gif)

Note that this is NOT a issue in `window_manager`, but gtk is.

gtk hide will reset offset of the window.

btw, i can reproduce this behavior of gtk also in [rust code](https://github.com/Kingtous/rust-collections/blob/master/examples/gtk-window.rs).
![Peek 2022-11-09 19-08](https://user-images.githubusercontent.com/39793325/200823393-9123e5a6-5a39-4c14-9748-c60a20c0b24f.gif)

But if I saved the size and offset before hide, and set them once after invoking hide, it behaves normally.
![after](https://user-images.githubusercontent.com/39793325/200823519-5c7249d8-77e1-48ca-9566-1d7d5e5b2b48.gif)

So I add a workaround to make linux able to remember offset and size after hide, which uniforms behaviors of all platforms supported by `window_manager`. (the position and offset of the window after hiding it can be saved automatically by system, but linux gtk can't). With this PR, window manager can remember the position and offset after hiding windows on all platforms.

