### PR TITLE
Linux: make `setTitleBarStyle()` GTK/HDY/CSD/SSD compatible

### DIFF
--- a/linux/window_manager_plugin.cc
+++ b/linux/window_manager_plugin.cc
@@ -452,7 +452,8 @@ static FlMethodResponse* set_title_bar_style(WindowManagerPlugin* self,
     gtk_window_set_decorated(get_window(self), normal);
   }
 
-  self->title_bar_style_ = strdup(title_bar_style);
+  g_free(self->title_bar_style_);
+  self->title_bar_style_ = g_strdup(title_bar_style);
 
   g_autoptr(FlValue) result = fl_value_new_bool(true);
   return FL_METHOD_RESPONSE(fl_method_success_response_new(result));
@@ -816,6 +817,8 @@ static void window_manager_plugin_handle_method_call(
 }
 
 static void window_manager_plugin_dispose(GObject* object) {
+  WindowManagerPlugin* self = WINDOW_MANAGER_PLUGIN(object);
+  g_free(self->title_bar_style_);
   G_OBJECT_CLASS(window_manager_plugin_parent_class)->dispose(object);
 }
 


### PR DESCRIPTION
When it comes to hiding the window title bar, there are a few cases to consider.

1. The default Flutter app template defaults to a server-side decorated window title on non-GNOME X11 desktops.
2. Any desktop running on Wayland, and GNOME on X11, default to a client-side decorated `GtkHeaderBar`.
3. Furthermore, the [handy_window](https://pub.dev/packages/handy_window) package, which is popular in Flutter-based Ubuntu apps, provides a more modern-looking `HdyWindow` with rounded bottom corners and the header bar replaced by `HdyHeaderBar`.

This PR ensures that `setTitleBarStyle()` works in all these three cases on Linux.