### PR TITLE
[Windows] Fix set maximizable throwing an error

### DIFF
--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -435,7 +435,7 @@ class WindowManager {
     final Map<String, dynamic> arguments = {
       'isMaximizable': isMaximizable,
     };
-    _channel.invokeListMethod('setMaximizable', arguments);
+    _channel.invokeMethod('setMaximizable', arguments);
   }
 
   /// Sets whether the window can be manually closed by user.

--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -431,11 +431,11 @@ class WindowManager {
   }
 
   /// Sets whether the window can be manually maximized by the user.
-  setMaximizable(bool isMaximizable) {
+  Future<void> setMaximizable(bool isMaximizable) async {
     final Map<String, dynamic> arguments = {
       'isMaximizable': isMaximizable,
     };
-    _channel.invokeMethod('setMaximizable', arguments);
+    await _channel.invokeMethod('setMaximizable', arguments);
   }
 
   /// Sets whether the window can be manually closed by user.


### PR DESCRIPTION
An error is thrown when we call setMaximizable because we are using invokeListMethod, instead of invokeMethod.
- Replace invokeListMethod with invokeMethod
- Modify method to be asynchronous

Fixes https://github.com/leanflutter/window_manager/issues/219