### PR TITLE
[linux] fix `on_window_show` and `on_window_hide` signatures

### DIFF
--- a/linux/window_manager_plugin.cc
+++ b/linux/window_manager_plugin.cc
@@ -898,13 +898,13 @@ gboolean on_window_blur(GtkWidget* widget, GdkEvent* event, gpointer data) {
   return false;
 }
 
-gboolean on_window_show(GtkWidget* widget, GdkEvent* event, gpointer data) {
+gboolean on_window_show(GtkWidget* widget, gpointer data) {
   WindowManagerPlugin* plugin = WINDOW_MANAGER_PLUGIN(data);
   _emit_event(plugin, "show");
   return false;
 }
 
-gboolean on_window_hide(GtkWidget* widget, GdkEvent* event, gpointer data) {
+gboolean on_window_hide(GtkWidget* widget, gpointer data) {
   WindowManagerPlugin* plugin = WINDOW_MANAGER_PLUGIN(data);
   _emit_event(plugin, "hide");
   return false;


### PR DESCRIPTION
The [GtkWidget::show](https://docs.gtk.org/gtk3/vfunc.Widget.show.html) and [GtkWidget::hide](https://docs.gtk.org/gtk3/vfunc.Widget.hide.html) signals do not have any "event" argument. It's important to have the correct signature to ensure that the user data argument points to the correct memory address.