### PR TITLE
Don't crash if an event doesn't have a dedicated handler

### DIFF
--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -67,7 +67,7 @@ class WindowManager {
         kWindowEventEnterFullScreen: listener.onWindowEnterFullScreen,
         kWindowEventLeaveFullScreen: listener.onWindowLeaveFullScreen,
       };
-      funcMap[eventName]!();
+      funcMap[eventName]?.call();
     }
   }
 


### PR DESCRIPTION
Fixes: #246