### PR TITLE
Linux: avoid removing shadows if no title is set

### DIFF
--- a/linux/window_manager_plugin.cc
+++ b/linux/window_manager_plugin.cc
@@ -492,7 +492,10 @@ static FlMethodResponse* set_title_bar_style(WindowManagerPlugin* self,
   if (header_bar != nullptr) {
     gtk_widget_set_visible(header_bar, normal);
   } else {
-    gtk_window_set_decorated(get_window(self), normal);
+    const gchar* title = gtk_window_get_title(get_window(self));
+    if (title != nullptr) {
+      gtk_window_set_decorated(get_window(self), normal);
+    }
   }
 
   g_free(self->title_bar_style_);


### PR DESCRIPTION
If a window doesn't have a textual title set at all, don't remove its decorations (shadows) when calling `setTitleBarStyle(hidden)`.