### PR TITLE
[linux] remove the margins of the window frame

### DIFF
--- a/example/linux/my_application.cc
+++ b/example/linux/my_application.cc
@@ -49,7 +49,7 @@ static void my_application_activate(GApplication* application) {
   }
 
   gtk_window_set_default_size(window, 1280, 720);
-  gtk_widget_show(GTK_WIDGET(window));
+  gtk_widget_realize(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);

--- a/lib/src/widgets/virtual_window_frame.dart
+++ b/lib/src/widgets/virtual_window_frame.dart
@@ -10,8 +10,6 @@ import 'package:window_manager/src/window_manager.dart';
 final _kIsLinux = !kIsWeb && Platform.isLinux;
 final _kIsWindows = !kIsWeb && Platform.isWindows;
 
-double get kVirtualWindowFrameMargin => (_kIsLinux) ? 20.0 : 0;
-
 class VirtualWindowFrame extends StatefulWidget {
   const VirtualWindowFrame({
     Key? key,
@@ -45,9 +43,6 @@ class _VirtualWindowFrameState extends State<VirtualWindowFrame>
 
   Widget _buildVirtualWindowFrame(BuildContext context) {
     return Container(
-      margin: (_isMaximized || _isFullScreen)
-          ? EdgeInsets.zero
-          : EdgeInsets.all(kVirtualWindowFrameMargin),
       decoration: BoxDecoration(
         color: Colors.transparent,
         border: Border.all(
@@ -79,9 +74,6 @@ class _VirtualWindowFrameState extends State<VirtualWindowFrame>
   Widget build(BuildContext context) {
     if (_kIsLinux) {
       return DragToResizeArea(
-        resizeEdgeMargin: (_isMaximized || _isFullScreen)
-            ? EdgeInsets.zero
-            : EdgeInsets.all(kVirtualWindowFrameMargin * 0.6),
         enableResizeEdges: (_isMaximized || _isFullScreen) ? [] : null,
         child: _buildVirtualWindowFrame(context),
       );


### PR DESCRIPTION
To avoid first displaying a window as Server-side Decoration and then changing it to Client-side Decoration.
Use 'gtk_widget_realize' instead of 'gtk_widget_show' in the example.