### PR TITLE
Moved calls to `super.initState()` to the top of overrides to conform with documented method contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> with WindowListener {
   @override
   void initState() {
-    windowManager.addListener(this);
     super.initState();
+    windowManager.addListener(this);
   }
 
   @override
@@ -305,9 +305,9 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> with WindowListener {
   @override
   void initState() {
+    super.initState();
     windowManager.addListener(this);
     _init();
-    super.initState();
   }
 
   @override
@@ -466,8 +466,8 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> with WindowListener {
   @override
   void initState() {
-    windowManager.addListener(this);
     super.initState();
+    windowManager.addListener(this);
   }
 
   @override


### PR DESCRIPTION

From the documentation of `initState()` of the `State` class: "Implementations of this method should start with a call to the inherited method, as in super.initState()." (https://api.flutter.dev/flutter/widgets/State/initState.html). So to make sure the examples conform with the contract of this method I moved the calls to `super.initState()` to the beginning in each of the overrides.

Obviously I'm assuming that this does not have any impact on the windowManager-related logic, but I could be wrong. In that case, a small comment or an explanation in the documentation as to why it is necessary to do it this way would be useful.