### PR TITLE
fixes setMinimumSize and setMaximumSize on macos

### DIFF
--- a/macos/Classes/WindowManager.swift
+++ b/macos/Classes/WindowManager.swift
@@ -273,16 +273,16 @@ public class WindowManager: NSObject, NSWindowDelegate {
     
     public func setMinimumSize(_ args: [String: Any]) {
         let minSize: NSSize = NSSize(
-            width: CGFloat(args["width"] as! Float),
-            height: CGFloat(args["height"] as! Float)
+            width: CGFloat((args["width"] as! NSNumber).floatValue),
+            height: CGFloat((args["height"] as! NSNumber).floatValue)
         )
         mainWindow.minSize = minSize
     }
     
     public func setMaximumSize(_ args: [String: Any]) {
         let maxSize: NSSize = NSSize(
-            width: CGFloat(args["width"] as! Float),
-            height: CGFloat(args["height"] as! Float)
+            width: CGFloat((args["width"] as! NSNumber).floatValue),
+            height: CGFloat((args["height"] as! NSNumber).floatValue)
         )
         mainWindow.maxSize = maxSize
     }


### PR DESCRIPTION
fixes Foundation/NSNumber.swift:467: Fatal error: Unable to bridge NSNumber to Float