### PR TITLE
fix: on-close event handler not be triggered on flutter >= 3.10

### DIFF
--- a/linux/window_manager_plugin.cc
+++ b/linux/window_manager_plugin.cc
@@ -1063,6 +1063,14 @@ void window_manager_plugin_register_with_registrar(
   plugin->window_geometry.min_height = -1;
   plugin->window_geometry.max_width = G_MAXINT;
   plugin->window_geometry.max_height = G_MAXINT;
+
+  // Disconnect all delete-event handlers first in flutter 3.10.1, which causes delete_event not working.
+  // Issues from flutter/engine: https://github.com/flutter/engine/pull/40033 
+  guint handler_id = g_signal_handler_find(get_window(plugin), G_SIGNAL_MATCH_DATA, 0, 0, NULL, NULL, fl_plugin_registrar_get_view(plugin->registrar));
+  if (handler_id > 0) {
+    g_signal_handler_disconnect(get_window(plugin), handler_id);
+  }
+
   g_signal_connect(get_window(plugin), "delete_event",
                    G_CALLBACK(on_window_close), plugin);
   g_signal_connect(get_window(plugin), "focus-in-event",


### PR DESCRIPTION
This PR adds a workaround to remove the `delete-event` handlers in the flutter engine on Linux, which breaks the propagation of `on-close` event.

Note that it only happens on flutter >= 3.10, and the problem is brought by https://github.com/flutter/engine/pull/40033#discussion_r1200216166.

Future: this pr may break some latest api provided by Flutter, but currently we must fix the `setPreventClose` to ensure the validity of this important and core function. latest api: https://github.com/flutter/flutter/issues/30735
