### PR TITLE
[Windows] Better fullscreen implementation

### DIFF
--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -930,7 +930,7 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
             // ],
           ),
           child: Scaffold(
-            appBar: PreferredSize(
+            appBar: _isFullScreen ? null : PreferredSize(
               preferredSize: const Size.fromHeight(kWindowCaptionHeight),
               child: WindowCaption(
                 brightness: Theme.of(context).brightness,

--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -261,7 +261,7 @@ class WindowManager {
     await _channel.invokeMethod('setFullScreen', arguments);
     // (Windows) Force refresh the app so it 's back to the correct size
     // (see GitHub issue #311)
-    if (!isFullScreen && Platform.isWindows) {
+    if (Platform.isWindows) {
       final size = await getSize();
       setSize(size + const Offset(1, 1));
       setSize(size);
@@ -704,14 +704,16 @@ class WindowManager {
 
   /// Starts a window drag based on the specified mouse-down event.
   Future<void> startDragging() async {
+    if (Platform.isWindows && await isFullScreen()) return;
     await _channel.invokeMethod('startDragging');
   }
 
   /// Starts a window resize based on the specified mouse-down & mouse-move event.
   ///
   /// @platforms linux,windows
-  Future<void> startResizing(ResizeEdge resizeEdge) {
-    return _channel.invokeMethod<bool>(
+  Future<void> startResizing(ResizeEdge resizeEdge) async {
+    if (Platform.isWindows && await isFullScreen()) return;
+    await _channel.invokeMethod<bool>(
       'startResizing',
       {
         'resizeEdge': describeEnum(resizeEdge),

--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -703,12 +703,14 @@ class WindowManager {
   }
 
   /// Starts a window drag based on the specified mouse-down event.
+  /// On Windows, this is disabled during full screen mode.
   Future<void> startDragging() async {
     if (Platform.isWindows && await isFullScreen()) return;
     await _channel.invokeMethod('startDragging');
   }
 
   /// Starts a window resize based on the specified mouse-down & mouse-move event.
+  /// On Windows, this is disabled during full screen mode.
   ///
   /// @platforms linux,windows
   Future<void> startResizing(ResizeEdge resizeEdge) async {

--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -140,6 +140,7 @@ class WindowManager {
   static constexpr auto kFlutterViewWindowClassName = L"FLUTTERVIEW";
   bool g_is_window_fullscreen = false;
   std::string g_title_bar_style_before_fullscreen;
+  RECT g_frame_before_fullscreen;
   bool g_maximized_before_fullscreen;
   LONG g_style_before_fullscreen;
   ITaskbarList3* taskbar_ = nullptr;

--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -112,19 +112,23 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
     window_manager->pixel_ratio_ = (float) LOWORD(wParam) / USER_DEFAULT_SCREEN_DPI;
   }
 
-  if (message == WM_NCCALCSIZE) {
-    // This must always be first or else the one of other two ifs will execute
-    //  when window is in full screen and we don't want that
-    if (wParam && window_manager->IsFullScreen()) {
+  if (wParam && message == WM_NCCALCSIZE && window_manager->title_bar_style_ != "normal") {
+    if (window_manager->IsFullScreen()) {
+      if (window_manager->is_frameless_) {
+      NCCALCSIZE_PARAMS* sz = reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam);
+        sz->rgrc[0].left += 8;
+        sz->rgrc[0].top += 8;
+        sz->rgrc[0].right -= 8;
+        sz->rgrc[0].bottom -= 8;
+      }
       return 0;
     }
-
     // This must always be before handling title_bar_style_ == "hidden" so
-    //  the if TitleBarStyle.hidden doesn't get executed.
-    if (wParam && window_manager->is_frameless_) {
+    // the `if TitleBarStyle.hidden` doesn't get executed.
+    if (window_manager->is_frameless_) {
       NCCALCSIZE_PARAMS* sz = reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam);
-      // Add borders when maximized so app doesn't get cut off.
       if (window_manager->IsMaximized()) {
+        // Add borders when maximized so app doesn't get cut off.
         sz->rgrc[0].left += 8;
         sz->rgrc[0].top += 8;
         sz->rgrc[0].right -= 8;


### PR DESCRIPTION
Uses a modified method suggested by [this comment by @alexmercerind](https://github.com/leanflutter/window_manager/pull/359#pullrequestreview-1501577990), which in general reduces flicker when going to full screen and just behaves more predictable.

Todo:
- [X] Remove unused code.
- [X] Add comments .

## How `setFullScreen(true)` works now

1. Native window title bar is removed.
2. Remove/hide custom title bar widget (Developers should do this themselves).
3. Borders (including the rounded corners) are removed
4. Window is maximized to fit the whole screen.
5. Prevent the user from resizing the window (disables `startResizing()`)
6. Prevent the user from dragging/moving the window (disables `startDragging()`)