### PR TITLE
[Windows] Fix `flutter_acrylic` compatibility

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:bot_toast/bot_toast.dart';
+import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:window_manager/window_manager.dart';
 
 import './pages/home.dart';
@@ -8,6 +9,7 @@ import 'utilities/utilities.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await Window.initialize();
   await windowManager.ensureInitialized();
 
   WindowOptions windowOptions = const WindowOptions(
@@ -18,12 +20,15 @@ void main() async {
     titleBarStyle: TitleBarStyle.hidden,
     windowButtonVisibility: false,
   );
+
+  runApp(const MyApp());
+
   windowManager.waitUntilReadyToShow(windowOptions, () async {
     await windowManager.show();
     await windowManager.focus();
   });
 
-  runApp(const MyApp());
+  Window.setEffect(effect: WindowEffect.mica);
 }
 
 class MyApp extends StatefulWidget {
@@ -34,12 +39,19 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  ThemeMode _themeMode = ThemeMode.light;
+  ThemeMode _themeMode = ThemeMode.system;
+  bool _useNativeBackground = true;
 
   @override
   void initState() {
     sharedConfigManager.addListener(_configListen);
     super.initState();
+
+    var window = WidgetsBinding.instance.platformDispatcher;
+    window.onPlatformBrightnessChanged = () {
+      WidgetsBinding.instance.handlePlatformBrightnessChanged();
+      windowManager.setBrightness(window.platformBrightness);
+    };
   }
 
   @override
@@ -50,6 +62,7 @@ class _MyAppState extends State<MyApp> {
 
   void _configListen() {
     _themeMode = sharedConfig.themeMode;
+    _useNativeBackground = sharedConfig.useNativeBackground;
     setState(() {});
   }
 
@@ -60,8 +73,17 @@ class _MyAppState extends State<MyApp> {
 
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      theme: lightThemeData,
-      darkTheme: darkThemeData,
+      theme: lightThemeData.copyWith(
+        scaffoldBackgroundColor:
+            _useNativeBackground ? Colors.transparent : null,
+        canvasColor: _useNativeBackground ? Colors.white54 : null,
+        cardColor: null,
+      ),
+      darkTheme: darkThemeData.copyWith(
+        scaffoldBackgroundColor:
+            _useNativeBackground ? Colors.transparent : null,
+        canvasColor: _useNativeBackground ? Colors.black26 : null,
+      ),
       themeMode: _themeMode,
       builder: (context, child) {
         child = virtualWindowFrameBuilder(context, child);

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:bot_toast/bot_toast.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:preference_list/preference_list.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:window_manager/window_manager.dart';
@@ -123,19 +124,229 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
               title: const Text('ThemeMode'),
               detailText: Text('${sharedConfig.themeMode}'),
               onTap: () async {
-                ThemeMode newThemeMode =
-                    sharedConfig.themeMode == ThemeMode.light
-                        ? ThemeMode.dark
-                        : ThemeMode.light;
+                ThemeMode newThemeMode;
+                if (sharedConfig.themeMode == ThemeMode.light) {
+                  newThemeMode = ThemeMode.dark;
+                } else if (sharedConfig.themeMode == ThemeMode.dark) {
+                  newThemeMode = ThemeMode.system;
+                } else {
+                  newThemeMode = ThemeMode.light;
+                }
+
+                final brightness = {
+                  ThemeMode.light: Brightness.light,
+                  ThemeMode.dark: Brightness.dark,
+                  ThemeMode.system: MediaQuery.of(context).platformBrightness,
+                };
 
                 await sharedConfigManager.setThemeMode(newThemeMode);
-                await windowManager.setBrightness(
-                  newThemeMode == ThemeMode.light
-                      ? Brightness.light
-                      : Brightness.dark,
-                );
+                await windowManager.setBrightness(brightness[newThemeMode]!);
+                setState(() {});
               },
             ),
+          ],
+        ),
+        PreferenceListSection(
+          title: const Text('flutter_acrylic'),
+          children: [
+            PreferenceListSwitchItem(
+              title: const Text('Use Native Background'),
+              value: sharedConfig.useNativeBackground,
+              onChanged: (value) {
+                sharedConfigManager.setUseNativeBackground(value);
+                setState(() {});
+              },
+            ),
+            PreferenceListItem(
+              title: const Text('Window.setEffect'),
+              accessoryView: SizedBox(
+                width: 300,
+                child: Wrap(
+                  children: [
+                    CupertinoButton(
+                      child: const Text('WindowEffect.transparent'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.transparent,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.disabled'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.disabled,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.solid'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.solid,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.aero'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.aero,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.acrylic'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.acrylic,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.mica'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.mica,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.tabbed'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.tabbed,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.titlebar'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.titlebar,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.menu'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.menu,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.popover'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.popover,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.sidebar'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.sidebar,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.headerView'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.headerView,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.sheet'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.sheet,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.windowBackground'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.windowBackground,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.hudWindow'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.hudWindow,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.fullScreenUI'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.fullScreenUI,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.toolTip'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.toolTip,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.contentBackground'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.contentBackground,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.underWindowBackground'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.underWindowBackground,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                    CupertinoButton(
+                      child: const Text('WindowEffect.underPageBackground'),
+                      onPressed: () async {
+                        await Window.setEffect(
+                          effect: WindowEffect.underPageBackground,
+                          dark: Theme.of(context).brightness == Brightness.dark,
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            )
           ],
         ),
         PreferenceListSection(
@@ -918,8 +1129,10 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
       children: [
         Container(
           margin: const EdgeInsets.all(0),
-          decoration: const BoxDecoration(
-            color: Colors.white,
+          decoration: BoxDecoration(
+            color: sharedConfig.useNativeBackground
+                ? Colors.transparent
+                : Colors.white,
             // border: Border.all(color: Colors.grey.withOpacity(0.4), width: 1),
             // boxShadow: <BoxShadow>[
             //   BoxShadow(
@@ -956,7 +1169,9 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
                     margin: const EdgeInsets.all(0),
                     width: double.infinity,
                     height: 54,
-                    color: Colors.grey.withOpacity(0.3),
+                    color: sharedConfig.useNativeBackground
+                        ? Theme.of(context).canvasColor.withOpacity(.25)
+                        : Colors.grey.withOpacity(0.3),
                     child: const Center(
                       child: Text('DragToMoveArea'),
                     ),
@@ -972,7 +1187,9 @@ class _HomePageState extends State<HomePage> with TrayListener, WindowListener {
                       child: Container(
                         width: double.infinity,
                         height: double.infinity,
-                        color: Colors.grey.withOpacity(0.3),
+                        color: sharedConfig.useNativeBackground
+                            ? Theme.of(context).canvasColor.withOpacity(.5)
+                            : Colors.grey.withOpacity(0.3),
                         child: Center(
                           child: GestureDetector(
                             child: const Text('DragToResizeArea'),

--- a/example/lib/utilities/config.dart
+++ b/example/lib/utilities/config.dart
@@ -57,7 +57,9 @@ class Config {
   /// The shared instance of [Config].
   static final Config instance = Config._();
 
-  ThemeMode themeMode = ThemeMode.light;
+  ThemeMode themeMode = ThemeMode.system;
+
+  bool useNativeBackground = true;
 }
 
 class ConfigManager extends _ConfigChangeNotifier {
@@ -70,6 +72,11 @@ class ConfigManager extends _ConfigChangeNotifier {
 
   Future<void> setThemeMode(ThemeMode value) async {
     sharedConfig.themeMode = value;
+    notifyListeners();
+  }
+
+  Future<void> setUseNativeBackground(bool value) async {
+    sharedConfig.useNativeBackground = value;
     notifyListeners();
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -78,6 +78,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_acrylic:
+    dependency: "direct main"
+    description:
+      name: flutter_acrylic
+      sha256: a9a1fdf91ff1fb47858fd82507f57e255a132a5d355056694fdb9fd303633b18
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -122,6 +130,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  macos_window_utils:
+    dependency: transitive
+    description:
+      name: macos_window_utils
+      sha256: "43a90473f8786f00f07203e6819dab67e032f8896dafa4a6f85fbc71fba32c0b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
@@ -304,4 +320,4 @@ packages:
     version: "0.3.5"
 sdks:
   dart: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.7.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  flutter_acrylic: ^1.1.3
 
 dev_dependencies:
   flutter_test:

--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -141,9 +141,11 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
     if (wParam && window_manager->title_bar_style_ == "hidden") {
       NCCALCSIZE_PARAMS* sz = reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam);
 
-      // Add 8 pixel to the top border when maximized so the app isn't cut off
+      // Add 9 pixel to the top border when maximized so the app isn't cut off
+      // Previously 8 pixels, but Chrome -for example- actually leaves 1 pixel at the top, presumably for
+      // the Windows taskbar.
       if (window_manager->IsMaximized()) {
-        sz->rgrc[0].top += 8;
+        sz->rgrc[0].top += 9;
       } else {
         // on windows 10, if set to 0, there's a white line at the top
         // of the app and I've yet to find a way to remove that.

--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -184,9 +184,7 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
     } else {
       _EmitEvent("blur");
     }
-
-    if (window_manager->title_bar_style_ == "hidden" ||
-        window_manager->is_frameless_)
+    if (window_manager->is_frameless_)
       return 1;
   } else if (message == WM_EXITSIZEMOVE) {
     if (window_manager->is_resizing_) {

--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -184,8 +184,6 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
     } else {
       _EmitEvent("blur");
     }
-    if (window_manager->is_frameless_)
-      return 1;
   } else if (message == WM_EXITSIZEMOVE) {
     if (window_manager->is_resizing_) {
       _EmitEvent("resized");


### PR DESCRIPTION
### 
Alright I've been kind of trying to fix this issue.
Here's what I found:
1. `WindowEffect.transparent` is compatible, no issues there.
2. `TitleBarStyle.hidden` is NOT compatible with `WindowEffect.mica`, `WindowEffect.acrylic`, and `WindowEffect.tabbed`. However, this can be workaround by calling `Window.setEffect` AFTER `setTitleBarStyle`.
For example, this will NOT work:
```dart

void main() async {
  WidgetsFlutterBinding.ensureInitialized();

  await Window.initialize();
  await windowManager.ensureInitialized();
  
  await Window.setEffect(effect: WindowEffect.tabbed);
  await windowManager.setTitleBarStyle(TitleBarStyle.hidden);

  runApp(const MyApp());

  await windowManager.show();
}
```
while this will work:
```dart

void main() async {
  WidgetsFlutterBinding.ensureInitialized();

  await Window.initialize();
  await windowManager.ensureInitialized();
  
  await windowManager.setTitleBarStyle(TitleBarStyle.hidden);
  await Window.setEffect(effect: WindowEffect.tabbed);

  runApp(const MyApp());

  await windowManager.show();
}
```

3.  Similar to above, `setFullScreen` is NOT compatible with `WindowEffect.mica`, `WindowEffect.acrylic`, and `WindowEffect.tabbed`. However, this can be workaround by calling `Window.setEffect` AFTER `setFullScreen`
4. `setAsFrameless()` is NOT compatible AT ALL with `WindowEffect.mica`, `WindowEffect.acrylic`, and `WindowEffect.tabbed`. No workaround found yet, probably never. What happens is that since [those effects needs the window frame](https://github.com/alexmercerind/flutter_acrylic/blob/2a3f7a2157ac432b0b1959ec65f93698d22d5491/windows/flutter_acrylic_plugin.cpp#L201-L252), `setAsFrameless` will be overridden, or the effects will be overridden, depends on which line is called first.
5. If `TitleBarStyle.hidden`, going from `WindowEffect.mica`, `WindowEffect.acrylic`, and `WindowEffect.tabbed` to `WindowEffect.transparent` results in a white line on the top of the window. The solution is to call `setTitleBarStyle(TitleBarStyle.hidden)` once again, after calling `setWindowEffect(WindowEffect.transparent)`.
6. Different `WindowEffect`s will result in different shadow. `WindowEffect.mica`, `WindowEffect.acrylic`, and `WindowEffect.tabbed` has shorter shadow than the rest.
7. `windowManager.setBackgroundColor` overrides all `WindowEffect`s

### Some Screenshots and Recording
transparent:
![image](https://github.com/leanflutter/window_manager/assets/25608913/e8d9274c-1cb8-4276-902a-d5c836bf9f06)

mica:
![image](https://github.com/leanflutter/window_manager/assets/25608913/472b0528-7b7d-4718-b1d2-638c8d1cafcb)

video:

https://github.com/leanflutter/window_manager/assets/25608913/01f1466f-4f50-4846-a962-43474e12771b


