### PR TITLE
Window Caption Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ static void my_application_activate(GApplication* application) {
 
 ...
 
-```
+```usage
 
 ##### macOS
 

--- a/lib/src/widgets/window_caption.dart
+++ b/lib/src/widgets/window_caption.dart
@@ -23,17 +23,33 @@ const double kWindowCaptionHeight = 32;
 /// )
 /// ```
 /// {@end-tool}
+/// 
+/// An optional List<Widget>[options] can be added to the [WindowCaption] to provide addtional buttons in the toolbar.
+/// Each child option will be displayed to the left of the minimize button.
+/// usage example (Adding a button to change themes from light to dark):
+/// ```dart
+/// WindowCaption(
+/// options: [
+///   WindowCaptionOption.icon(() { 
+///     ref.read(themeProvider.notifier).toggleDarkMode();
+///     }, 
+///     theme.darkMode ? Icons.dark_mode_outlined : Icons.light_mode),
+///   ],
+///),
+/// ```
 class WindowCaption extends StatefulWidget {
   const WindowCaption({
     Key? key,
     this.title,
     this.backgroundColor,
     this.brightness,
+    this.options
   }) : super(key: key);
 
   final Widget? title;
   final Color? backgroundColor;
   final Brightness? brightness;
+  final List<Widget>? options;
 
   @override
   State<WindowCaption> createState() => _WindowCaptionState();
@@ -86,6 +102,9 @@ class _WindowCaptionState extends State<WindowCaption> with WindowListener {
               ),
             ),
           ),
+          if(widget.options != null)
+          for(final option in widget.options!)
+          option,
           WindowCaptionButton.minimize(
             brightness: widget.brightness,
             onPressed: () async {

--- a/lib/src/widgets/window_caption_button.dart
+++ b/lib/src/widgets/window_caption_button.dart
@@ -182,6 +182,121 @@ class _WindowCaptionButtonState extends State<WindowCaptionButton> {
   }
 }
 
+/// The [WindowCaptionOption] widget is intended to be used within a [WindowCaption].
+/// When added to the list of the options, each window caption option will provide an addtional toolbar item with uneque [onPressed] callback.
+/// usage example (Adding a button to change themes from light to dark):
+/// ```dart
+/// WindowCaption(
+/// options: [
+///   WindowCaptionOption.icon(() { 
+///      ref.read(themeProvider.notifier).toggleDarkMode();
+///   }, 
+///   theme.darkMode ? Icons.dark_mode_outlined : Icons.light_mode),
+///   ],
+///),
+/// ```
+class WindowCaptionOption extends StatefulWidget {
+  WindowCaptionOption(this.onPressed, {
+    Key? key,
+    this.brightness,
+    this.icon,
+  }) : super(key: key);
+
+  WindowCaptionOption.icon(this.onPressed, IconData iconData,{
+    Key? key,
+    this.brightness,
+  })  :
+       icon = Icon(iconData, size: 18,),
+       super(key: key);
+
+  final Brightness? brightness;
+  final Widget? icon;
+  final VoidCallback onPressed;
+
+  final _ButtonBgColorScheme _lightButtonBgColorScheme = _ButtonBgColorScheme(
+    normal: Colors.transparent,
+    hovered: Colors.black.withOpacity(0.0373),
+    pressed: Colors.black.withOpacity(0.0241),
+  );
+  final _ButtonIconColorScheme _lightButtonIconColorScheme = _ButtonIconColorScheme(
+    normal: Colors.black.withOpacity(0.8956),
+    hovered: Colors.black.withOpacity(0.8956),
+    pressed: Colors.black.withOpacity(0.6063),
+    disabled: Colors.black.withOpacity(0.3614),
+  );
+  final _ButtonBgColorScheme _darkButtonBgColorScheme = _ButtonBgColorScheme(
+    normal: Colors.transparent,
+    hovered: Colors.white.withOpacity(0.0605),
+    pressed: Colors.white.withOpacity(0.0419),
+  );
+  final _ButtonIconColorScheme _darkButtonIconColorScheme = _ButtonIconColorScheme(
+    normal: Colors.white,
+    hovered: Colors.white,
+    pressed: Colors.white.withOpacity(0.786),
+    disabled: Colors.black.withOpacity(0.3628),
+  );
+
+  _ButtonBgColorScheme get buttonBgColorScheme => brightness != Brightness.dark
+      ? _lightButtonBgColorScheme
+      : _darkButtonBgColorScheme;
+
+  _ButtonIconColorScheme get buttonIconColorScheme =>
+      brightness != Brightness.dark
+          ? _lightButtonIconColorScheme
+          : _darkButtonIconColorScheme;
+
+  @override
+  State<WindowCaptionOption> createState() => _WindowCaptionOptionState();
+}
+
+class _WindowCaptionOptionState extends State<WindowCaptionOption> {
+  bool _isHovering = false;
+  bool _isPressed = false;
+
+  void _onEntered({required bool hovered}) {
+    setState(() => _isHovering = hovered);
+  }
+
+  void _onActive({required bool pressed}) {
+    setState(() => _isPressed = pressed);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Color bgColor = widget.buttonBgColorScheme.normal;
+
+    if (_isHovering) {
+      bgColor = widget.buttonBgColorScheme.hovered;
+    }
+    if (_isPressed) {
+      bgColor = widget.buttonBgColorScheme.pressed;
+    }
+
+    return MouseRegion(
+      onExit: (value) => _onEntered(hovered: false),
+      onHover: (value) => _onEntered(hovered: true),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTapDown: (_) => _onActive(pressed: true),
+        onTapCancel: () => _onActive(pressed: false),
+        onTapUp: (_) => _onActive(pressed: false),
+        onTap: widget.onPressed,
+        child: Container(
+          constraints: const BoxConstraints(minWidth: 46, minHeight: 32),
+          decoration: BoxDecoration(
+            color: bgColor,
+          ),
+          child: Center(
+            child: Opacity(
+              opacity: .7, 
+              child: widget.icon,) ,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _ButtonBgColorScheme {
   _ButtonBgColorScheme({
     required this.normal,


### PR DESCRIPTION
This PR Closes #373 and adds the ability to create additional window caption buttons using the `WindowCaptionOptionWidget`.  The `WindowCaption` widget now accepts a `List<Widget>?` as additional options. While any widget can be added to this list a new `WindowCaptionOption` widget has been provided to maintain a consistent style.  To begin using window caption options see the example below:

```dart
child: WindowCaption(
  options: [                            //Add a list of option widgets
    WindowCaptionOption.icon(() {       //Add one or many options
     toggleDarkMode();                  //execute logic, in this case we are toggling the theme brightness
    }, 
    darkMode                            //and changing the Icons displayed state using the current mode
    ? Icons.dark_mode_outlined 
    : Icons.light_mode),
  ],
),
```
