### PR TITLE
windows setIcon prepare path fix

### DIFF
--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -593,14 +593,7 @@ class WindowManager {
   ///
   /// @platforms windows
   Future<void> setIcon(String iconPath) async {
-    final Map<String, dynamic> arguments = {
-      'iconPath': path.joinAll([
-        path.dirname(Platform.resolvedExecutable),
-        'data',
-        'flutter_assets',
-        iconPath,
-      ]),
-    };
+    final Map<String, dynamic> arguments = {'iconPath': iconPath};
 
     await _channel.invokeMethod('setIcon', arguments);
   }

--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -596,7 +596,8 @@ class WindowManager {
     final Map<String, dynamic> arguments = {
       'iconPath': path.joinAll([
         path.dirname(Platform.resolvedExecutable),
-        'data/flutter_assets',
+        'data',
+        'flutter_assets',
         iconPath,
       ]),
     };


### PR DESCRIPTION
When using setIcon on windows i had no effect. Path for icon was not prepared properly because of path with "/" - Windows folder separator is "\\". 
Now path.joinAll handle whole path preparation.