### PR TITLE
fix: incorrect window size before/after `setTitleBarStyle`

### DIFF
--- a/lib/src/window_manager.dart
+++ b/lib/src/window_manager.dart
@@ -115,6 +115,13 @@ class WindowManager {
   ]) async {
     await _channel.invokeMethod('waitUntilReadyToShow');
 
+    if (options?.titleBarStyle != null) {
+      await setTitleBarStyle(
+        options!.titleBarStyle!,
+        windowButtonVisibility: options.windowButtonVisibility ?? true,
+      );
+    }
+
     if (await isFullScreen()) await setFullScreen(false);
     if (await isMaximized()) await unmaximize();
     if (await isMinimized()) await restore();
@@ -138,12 +145,6 @@ class WindowManager {
       await setSkipTaskbar(options!.skipTaskbar!);
     }
     if (options?.title != null) await setTitle(options!.title!);
-    if (options?.titleBarStyle != null) {
-      await setTitleBarStyle(
-        options!.titleBarStyle!,
-        windowButtonVisibility: options.windowButtonVisibility ?? true,
-      );
-    }
 
     if (callback != null) {
       callback();


### PR DESCRIPTION
- Fixes issue where setting both `size` and `setTitleBarStyle` using `WindowOptions` in `waitUntilReadyToShow` causes incorrect window size.

This is fixed by putting `titleBarStyle` handling before all other options so the OS calculates the window size and position correctly,