### PR TITLE
[Windows] Wrong window position in fullscreen mode with external monitor 

### DIFF
--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -575,9 +575,9 @@ void WindowManager::SetFullScreen(const flutter::EncodableMap& args) {
                      &monitor);
     ::SetWindowLongPtr(mainWindow, GWL_STYLE, g_style_before_fullscreen & ~WS_OVERLAPPEDWINDOW);
     ::SetWindowPos(mainWindow, HWND_TOP, monitor.rcMonitor.left,
-                   monitor.rcMonitor.top, monitor.rcMonitor.right,
-                   monitor.rcMonitor.bottom,
-                   SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
+                 monitor.rcMonitor.top, monitor.rcMonitor.right - monitor.rcMonitor.left,
+                 monitor.rcMonitor.bottom - monitor.rcMonitor.top,
+                 SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
     }
   } else {
     if (!g_maximized_before_fullscreen)


### PR DESCRIPTION
When the Flutter app is displayed in fullscreen mode on an external monitor, the window is not positioned as it should be because the position computed is wrong.