### PR TITLE
Fix WindowManager.IsFocused() method on Windows

### DIFF
--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -251,7 +251,7 @@ void WindowManager::Blur() {
 }
 
 bool WindowManager::IsFocused() {
-  return GetMainWindow() == GetActiveWindow();
+  return GetMainWindow() == GetForegroundWindow();
 }
 
 void WindowManager::Show() {


### PR DESCRIPTION
`WindowManager::IsFocused()` uses `GetActiveWindow()` which returns active window of the current application. It doesn't mean that this application is in foreground and has keyboard focus. The correct way is to use `GetForegroundWindow()` which this PR does.