### PR TITLE
Add UniControlHub to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ class _HomePageState extends State<HomePage> with WindowListener {
 - [Linwood Butterfly](https://github.com/LinwoodCloud/Butterfly) - Open source note taking app written in Flutter
 - [RustDesk](https://github.com/rustdesk/rustdesk) - Yet another remote desktop software, written in Rust. Works out of the box, no configuration required. 
 - [Ubuntu Desktop Installer](https://github.com/canonical/ubuntu-desktop-installer) - This project is a modern implementation of the Ubuntu Desktop installer.
+- [UniControlHub](https://github.com/rohitsangwan01/uni_control_hub) - Seamlessly bridge your Desktop and Mobile devices
 
 ## API
 


### PR DESCRIPTION
Adds `UniControlHub` to `who's using it` section of Readme
Note: Am the owner of [UniControlHub](https://github.com/rohitsangwan01/uni_control_hub)