### PR TITLE
fix: windows, window size, fullscree & maximized

### DIFF
--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -61,6 +61,15 @@ class WindowManagerPlugin : public flutter::Plugin {
   void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+  void adjustNCCALCSIZE(NCCALCSIZE_PARAMS* sz) {
+    LONG l = sz->rgrc[0].left;
+    LONG t = sz->rgrc[0].top;
+    sz->rgrc[0].left -= l;
+    sz->rgrc[0].top -= t;
+    sz->rgrc[0].right += l;
+    sz->rgrc[0].bottom += t;
+  }
 };
 
 // static
@@ -119,43 +128,30 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
     if (window_manager->IsFullScreen() &&
         window_manager->title_bar_style_ != "normal") {
       if (window_manager->is_frameless_) {
-        NCCALCSIZE_PARAMS* sz = reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam);
-        sz->rgrc[0].left += 8;
-        sz->rgrc[0].top += 8;
-        sz->rgrc[0].right -= 8;
-        sz->rgrc[0].bottom -= 8;
+        adjustNCCALCSIZE(reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam));
       }
       return 0;
     }
     // This must always be before handling title_bar_style_ == "hidden" so
     // the `if TitleBarStyle.hidden` doesn't get executed.
     if (window_manager->is_frameless_) {
-      NCCALCSIZE_PARAMS* sz = reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam);
       if (window_manager->IsMaximized()) {
-        // Add borders when maximized so app doesn't get cut off.
-        sz->rgrc[0].left += 8;
-        sz->rgrc[0].top += 8;
-        sz->rgrc[0].right -= 8;
-        sz->rgrc[0].bottom -= 9;
+        adjustNCCALCSIZE(reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam));
       }
       return 0;
     }
 
     // This must always be last.
     if (wParam && window_manager->title_bar_style_ == "hidden") {
-      NCCALCSIZE_PARAMS* sz = reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam);
-
-      // Add 8 pixel to the top border when maximized so the app isn't cut off
       if (window_manager->IsMaximized()) {
-        sz->rgrc[0].top += 8;
+        // Adjust the borders when maximized so the app isn't cut off
+        adjustNCCALCSIZE(reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam));
       } else {
+        NCCALCSIZE_PARAMS* sz = reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam);
         // on windows 10, if set to 0, there's a white line at the top
         // of the app and I've yet to find a way to remove that.
         sz->rgrc[0].top += IsWindows11OrGreater() ? 0 : 1;
       }
-      sz->rgrc[0].right -= 8;
-      sz->rgrc[0].bottom -= 8;
-      sz->rgrc[0].left -= -8;
 
       // Previously (WVR_HREDRAW | WVR_VREDRAW), but returning 0 or 1 doesn't
       // actually break anything so I've set it to 0. Unless someone pointed a


### PR DESCRIPTION
In the default example, the window height is incorrect when maximized.

## Reproduce steps

Windows -> Display settings -> Scale (any value other than 100%)

![image](https://github.com/user-attachments/assets/83af9ed4-79e9-438a-9cc2-4a2fcc6a8638)

Win11, scale `150%`, `2160x1440`, `window_manager` as an example (same logic).

1. `cd example && flutter run -d windows`
2. Find the output like `The Flutter DevTools debugger and profiler on Windows is available at: http://127.0.0.1:9105?uri=http://127.0.0.1:65189/_rHWjbz1MZA=/`, open the link.
3. Back the the example window, maxmize the window.
4. Check the window height. The number should be `912`, not `916`.

![image](https://github.com/user-attachments/assets/ddf8b688-e611-4e92-9c47-38a324528c63)


## Questions

1. Why the following code is not in the `if (window_manager->IsMaximized())` block

![image](https://github.com/user-attachments/assets/eae0974b-2dc5-4d24-8b33-5e95583bfcff)

2. Why do you use `9` instead of `8` here?

![image](https://github.com/user-attachments/assets/e16d117a-ecc9-47eb-a2f7-15428563d1d1)

