### PR TITLE
Windows bug: Update the window theme without taking into account the preferred theme.

### DIFF
--- a/windows/window_manager.cpp
+++ b/windows/window_manager.cpp
@@ -1020,21 +1020,12 @@ void WindowManager::SetOpacity(const flutter::EncodableMap& args) {
 }
 
 void WindowManager::SetBrightness(const flutter::EncodableMap& args) {
-  DWORD light_mode;
-  DWORD light_mode_size = sizeof(light_mode);
-  LSTATUS result =
-      RegGetValue(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
-                  kGetPreferredBrightnessRegValue, RRF_RT_REG_DWORD, nullptr,
-                  &light_mode, &light_mode_size);
-
-  if (result == ERROR_SUCCESS) {
-    std::string brightness =
-        std::get<std::string>(args.at(flutter::EncodableValue("brightness")));
-    HWND hWnd = GetMainWindow();
-    BOOL enable_dark_mode = light_mode == 0 && brightness == "dark";
-    DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
-                          &enable_dark_mode, sizeof(enable_dark_mode));
-  }
+  std::string brightness =
+      std::get<std::string>(args.at(flutter::EncodableValue("brightness")));
+  HWND hWnd = GetMainWindow();
+  BOOL enable_dark_mode = brightness == "dark";
+  DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                        &enable_dark_mode, sizeof(enable_dark_mode));
 }
 
 void WindowManager::SetIgnoreMouseEvents(const flutter::EncodableMap& args) {


### PR DESCRIPTION
#### Issue 
If the preferred system theme is lightMode, it is impossible to switch to darkMode, on Windows.
```dart
await windowManager.setBrightness(Brightness.light);
await windowManager.setBrightness(Brightness.dark);
```

#### Solution
The preferred theme should not be taken into account, like the MacOS implementation.
In the swift file for MacOS, the theme is simply updated by passing an argument :
```swift
public func setBrightness(_ args: [String: Any]) {
    let brightness: String = args["brightness"] as! String
    if (brightness == "dark") {
        mainWindow.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
    } else {
        mainWindow.appearance = NSAppearance(named: NSAppearance.Name.vibrantLight)
    }
    mainWindow.invalidateShadow()
}
```
But in the file for Windows, the system preferred theme is retrieved, and utilized incorrectly. Instead of doing: 
```cpp
BOOL enable_dark_mode = light_mode == 0 && brightness == "dark";
```
It should be:
```cpp
BOOL enable_dark_mode = brightness == "dark";
```

(Apologies, English isn't my first language.)