### PR TITLE
Update window_manager_plugin.cpp for fix 439 issue

### DIFF
--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -179,7 +179,7 @@ std::optional<LRESULT> WindowManagerPlugin::HandleWindowProc(HWND hWnd,
           window_manager->maximum_size_.y * window_manager->pixel_ratio_);
     result = 0;
   } else if (message == WM_NCACTIVATE) {
-    if (wParam == TRUE) {
+    if (wParam != 0) {
       _EmitEvent("focus");
     } else {
       _EmitEvent("blur");


### PR DESCRIPTION
Fix 439 issue: [Windows] Restoring window from minimized state triggers onWindowBlur instead of onWindowFocus.