### PR TITLE
fix: get window monitor from minimized state

### DIFF
--- a/windows/window_manager_plugin.cpp
+++ b/windows/window_manager_plugin.cpp
@@ -66,7 +66,12 @@ class WindowManagerPlugin : public flutter::Plugin {
     LONG l = 8;
     LONG t = 8;
 
-    HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    // HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    // Don't use `MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST)` above.
+    // Because if the window is restored from minimized state, the window is not in the correct monitor.
+    // The monitor is always the left-most monitor.
+    // https://github.com/leanflutter/window_manager/issues/489
+    HMONITOR monitor = MonitorFromRect(&sz->rgrc[0], MONITOR_DEFAULTTONEAREST);
     if (monitor != NULL) {
       MONITORINFO monitorInfo;
       monitorInfo.cbSize = sizeof(MONITORINFO);


### PR DESCRIPTION
https://github.com/leanflutter/window_manager/issues/489

Get window monitor when it is restored from minimized state(current maximized),


https://github.com/user-attachments/assets/e8a035f5-1355-413f-a0e4-5277ed2f30b0


