### PR TITLE
Initialize window_hints to fix minimum size setting in release mode

### DIFF
--- a/packages/window_manager/linux/window_manager_plugin.cc
+++ b/packages/window_manager/linux/window_manager_plugin.cc
@@ -1092,6 +1092,7 @@ void window_manager_plugin_register_with_registrar(
   plugin->window_geometry.min_height = -1;
   plugin->window_geometry.max_width = G_MAXINT;
   plugin->window_geometry.max_height = G_MAXINT;
+  plugin->window_hints = static_cast<GdkWindowHints>(0);
 
   // Disconnect all delete-event handlers first in flutter 3.10.1, which causes delete_event not working.
   // Issues from flutter/engine: https://github.com/flutter/engine/pull/40033 


### PR DESCRIPTION
When compiling in release mode for linux, the window size constraints (ie. `setMinimumSize`) weren't being enforced.

This happened because the `window_hints` variable was not initialized and contained garbage data (while it was zero in debug mode).