### PR TITLE
[Windows] Use frameless window to implement fullscreen

### DIFF
--- a/packages/window_manager/lib/src/window_manager.dart
+++ b/packages/window_manager/lib/src/window_manager.dart
@@ -263,11 +263,11 @@ class WindowManager {
     await _channel.invokeMethod('setFullScreen', arguments);
     // (Windows) Force refresh the app so it 's back to the correct size
     // (see GitHub issue #311)
-    if (Platform.isWindows) {
-      final size = await getSize();
-      setSize(size + const Offset(1, 1));
-      setSize(size);
-    }
+    // if (Platform.isWindows) {
+    //   final size = await getSize();
+    //   setSize(size + const Offset(1, 1));
+    //   setSize(size);
+    // }
   }
 
   /// Returns `bool` - Whether the window is dockable or not.


### PR DESCRIPTION
This may fixes #521 and fixes #211 
closes #456.

## Key Changes
1. Use `(WS_THICKFRAME | WS_MAXIMIZEBOX)` instead of `WS_OVERLAPPEDWINDOW` can avoid the native title bar appearing on exit fullscreen.
This is inspired by [this article](https://blog.lindexi.com/post/WPF-%E7%A8%B3%E5%AE%9A%E7%9A%84%E5%85%A8%E5%B1%8F%E5%8C%96%E7%AA%97%E5%8F%A3%E6%96%B9%E6%B3%95.html)
2. When the app is not maximized, call `SetAsFrameless` then change the app position and size **separately** (avoid UI stretching). To avoid UI freezing after enter fullscreen, the force refresh is removed.