### PR TITLE
test: Enable macos tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: "3.32.0"
+          flutter-version: "3.32.8"
       - run: |
           sudo apt-get update -y
           sudo apt-get install -y ninja-build libgtk-3-dev libayatana-appindicator3-dev xvfb
@@ -28,11 +28,10 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: "3.32.0"
+          flutter-version: "3.32.8"
       - uses: bluefireteam/melos-action@v3
-      # Blocked by https://github.com/flutter/flutter/issues/118469
-      # - working-directory: ./packages/window_manager/example
-      #   run: flutter test integration_test -v
+      - working-directory: ./packages/window_manager/example
+        run: flutter test integration_test -v
   integration_test-windows:
     runs-on: windows-latest
     steps:
@@ -40,7 +39,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: "3.32.0"
+          flutter-version: "3.32.8"
       - uses: bluefireteam/melos-action@v3
       - working-directory: ./packages/window_manager/example
         run: flutter test integration_test -v


### PR DESCRIPTION
Haven't executed, but theoretically the test on macos should work again.

See eE.g. https://github.com/bluefireteam/audioplayers/blob/f2269aeb270154e5f3571e1e025d340cfbca4686/.github/workflows/test.yml#L358